### PR TITLE
🚨 Remove ignored flag: -c copy

### DIFF
--- a/mp4-aac-to-ac3
+++ b/mp4-aac-to-ac3
@@ -16,6 +16,6 @@ for x in *.mp4; do
 		continue;
 	fi
 
-	ffmpeg -i "$x" -map 0 -c copy -c:a ac3 "$MKV"
+	ffmpeg -i "$x" -map 0 -c:a ac3 "$MKV"
 	rm -f "$x"
 done


### PR DESCRIPTION
Produces warning:
Multiple -c, -codec, -acodec, -vcodec, -scodec or -dcodec options specified for stream 1, only the last option '-c:a ac3' will be used.